### PR TITLE
fix: 左缘定位条贴会话区真实左缘 + 竖条半透明 pill 底衬提升对比度

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -99,23 +99,31 @@ const CSS = `
   z-index: 40;
   display: flex;
   flex-direction: column;
-  padding: 6px 0;
+  align-items: flex-start;
+  padding: 6px 2px;
 }
 .tidychat-nav-slot {
   display: flex;
   align-items: center;
   height: 18px;
-  width: 34px;
+  margin: 1px 0;
+  padding: 0 6px;
   cursor: pointer;
-  background: transparent;
+  background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 74%, transparent);
   border: none;
-  padding: 0;
+  border-radius: 6px;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.14),
+    inset 0 0 0 1px var(--dsw-alias-border-l2, rgba(128, 128, 128, 0.32));
+}
+.tidychat-nav-slot:hover {
+  background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 96%, transparent);
 }
 .tidychat-nav-bar {
   display: block;
   height: 3px;
   border-radius: 2px;
-  background: var(--dsw-alias-label-caption, rgba(127,127,127,0.5));
+  background: color-mix(in srgb, var(--dsw-alias-label-primary, #222) 78%, transparent);
   transition: width 120ms ease, background 120ms ease;
 }
 .tidychat-nav-bar.hot {
@@ -684,12 +692,12 @@ function apply(ctx) {
 		};
 	});
 	const measurePos = () => {
-		const host = document.querySelector("[data-slot=\"conversation.session\"]");
+		const host = document.querySelector("[data-conversation-scroll]");
 		if (host === null) return null;
 		const r = host.getBoundingClientRect();
 		if (r.width < 10 || r.height < 10) return null;
 		return {
-			left: r.left + 4,
+			left: r.left,
 			top: r.top + r.height * .5
 		};
 	};
@@ -798,7 +806,7 @@ function apply(ctx) {
 		};
 		if (users.length === 0) return null;
 		const style = pos === null ? {
-			left: "284px",
+			left: "280px",
 			top: "50vh"
 		} : {
 			left: pos.left + "px",

--- a/lib/client.js
+++ b/lib/client.js
@@ -109,6 +109,7 @@ const CSS = `
   margin: 1px 0;
   padding: 0 6px;
   cursor: pointer;
+  background: transparent; /* 旧浏览器兜底：color-mix 不支持时退回无底衬 */
   background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 74%, transparent);
   border: none;
   border-radius: 6px;
@@ -117,12 +118,14 @@ const CSS = `
     inset 0 0 0 1px var(--dsw-alias-border-l2, rgba(128, 128, 128, 0.32));
 }
 .tidychat-nav-slot:hover {
+  background: transparent; /* 旧浏览器兜底 */
   background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 96%, transparent);
 }
 .tidychat-nav-bar {
   display: block;
   height: 3px;
   border-radius: 2px;
+  background: var(--dsw-alias-label-caption, rgba(127, 127, 127, 0.5)); /* 旧浏览器兜底：保证竖条有颜色 */
   background: color-mix(in srgb, var(--dsw-alias-label-primary, #222) 78%, transparent);
   transition: width 120ms ease, background 120ms ease;
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -69,23 +69,31 @@ const CSS = `
   z-index: 40;
   display: flex;
   flex-direction: column;
-  padding: 6px 0;
+  align-items: flex-start;
+  padding: 6px 2px;
 }
 .tidychat-nav-slot {
   display: flex;
   align-items: center;
   height: 18px;
-  width: 34px;
+  margin: 1px 0;
+  padding: 0 6px;
   cursor: pointer;
-  background: transparent;
+  background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 74%, transparent);
   border: none;
-  padding: 0;
+  border-radius: 6px;
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.14),
+    inset 0 0 0 1px var(--dsw-alias-border-l2, rgba(128, 128, 128, 0.32));
+}
+.tidychat-nav-slot:hover {
+  background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 96%, transparent);
 }
 .tidychat-nav-bar {
   display: block;
   height: 3px;
   border-radius: 2px;
-  background: var(--dsw-alias-label-caption, rgba(127,127,127,0.5));
+  background: color-mix(in srgb, var(--dsw-alias-label-primary, #222) 78%, transparent);
   transition: width 120ms ease, background 120ms ease;
 }
 .tidychat-nav-bar.hot {
@@ -664,11 +672,14 @@ export function apply(ctx: any): void {
   })
 
   const measurePos = (): { left: number; top: number } | null => {
-    const host = document.querySelector('[data-slot="conversation.session"]')
+    // 新版 DSH 里 [data-slot="conversation.session"] 是 0×0 的空壳元素（slot host 未参与布局），
+    // 用它测 rect 必然返回 null，导致定位条永远落到写死的 fallback。
+    // 改用真实会话滚动容器 [data-conversation-scroll] 作为锚点，贴住会话区实际左缘。
+    const host = document.querySelector('[data-conversation-scroll]')
     if (host === null) return null
     const r = host.getBoundingClientRect()
     if (r.width < 10 || r.height < 10) return null
-    return { left: r.left + 4, top: r.top + r.height * 0.5 }
+    return { left: r.left, top: r.top + r.height * 0.5 }
   }
 
   const hhmm = (ms: number): string => {
@@ -767,7 +778,7 @@ export function apply(ctx: any): void {
 
       if (users.length === 0) return null
       const style = pos === null
-        ? { left: '284px', top: '50vh' }
+        ? { left: '280px', top: '50vh' }
         : { left: pos.left + 'px', top: pos.top + 'px' }
       const rail = React.createElement('div', {
         className: 'tidychat-nav-rail',

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -79,6 +79,7 @@ const CSS = `
   margin: 1px 0;
   padding: 0 6px;
   cursor: pointer;
+  background: transparent; /* 旧浏览器兜底：color-mix 不支持时退回无底衬 */
   background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 74%, transparent);
   border: none;
   border-radius: 6px;
@@ -87,12 +88,14 @@ const CSS = `
     inset 0 0 0 1px var(--dsw-alias-border-l2, rgba(128, 128, 128, 0.32));
 }
 .tidychat-nav-slot:hover {
+  background: transparent; /* 旧浏览器兜底 */
   background: color-mix(in srgb, var(--dsw-alias-bg-layer-3, #fff) 96%, transparent);
 }
 .tidychat-nav-bar {
   display: block;
   height: 3px;
   border-radius: 2px;
+  background: var(--dsw-alias-label-caption, rgba(127, 127, 127, 0.5)); /* 旧浏览器兜底：保证竖条有颜色 */
   background: color-mix(in srgb, var(--dsw-alias-label-primary, #222) 78%, transparent);
   transition: width 120ms ease, background 120ms ease;
 }


### PR DESCRIPTION
- measurePos 锚点从 0×0 的 [data-slot=conversation.session] 改为 [data-conversation-scroll]，定位条动态贴住会话区实际左缘（展开/收起侧栏自适应），不再落死 fallback 284px
- 竖条改为 label-primary 78% 深色（浅色主题深条/深色主题浅条）+ 每条竖条加半透明 bg-layer-3 pill 底衬，主题宫邸背景下仍清晰可读