### PR TITLE
fix: 悬停摘要泡泡文字色被样式主题 color:inherit 覆盖导致不可读

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -107,7 +107,11 @@ const CSS = `
   cursor: pointer;
   touch-action: none;
 }
-.tidychat-nav-tip {
+/* 双类名 + !important：泡泡挂载在顶栏 header 内，部分样式主题（如 maid-atelier 换肤）会写
+   「header 内所有 nav/span/button/a/div」这类大范围 color:inherit 规则，优先级约 (0,3,2)，
+   单类名声明 (0,1,0) 必败，导致文字继承主题顶栏的浅色、落在浅色泡泡上不可读。
+   变量链保留：皮肤仍可通过 --tidychat-nav-tip-text / --tidychat-nav-tip-head 定制。 */
+.tidychat-nav-tip.tidychat-nav-tip {
   position: fixed;
   z-index: 41;
   pointer-events: none;
@@ -119,11 +123,11 @@ const CSS = `
   padding: 6px 10px;
   font-size: 12px;
   line-height: 1.5;
-  color: var(--tidychat-nav-tip-text, var(--dsw-alias-label-primary, #222));
+  color: var(--tidychat-nav-tip-text, var(--dsw-alias-label-primary, #222)) !important;
   overflow-wrap: anywhere; /* 摘要含长代码/长串时在框内折行，不撑破卡片 */
 }
 .tidychat-nav-tip-head {
-  color: var(--tidychat-nav-tip-head, var(--dsw-alias-label-secondary, #666));
+  color: var(--tidychat-nav-tip-head, var(--dsw-alias-label-secondary, #666)) !important;
   font-size: 11px;
   margin-bottom: 2px;
 }
@@ -1167,7 +1171,7 @@ function apply(ctx) {
 	};
 	const applyTipContrast = () => {
 		const root = document.documentElement;
-		const cs = getComputedStyle(document.documentElement);
+		const cs = getComputedStyle(document.body);
 		const tipBg = parseRgba(cs.getPropertyValue("--dsw-alias-bg-layer-3").trim());
 		const update = (key, token) => {
 			if (tipBg === null || tipBg[3] < .85) {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -80,7 +80,11 @@ const CSS = `
   cursor: pointer;
   touch-action: none;
 }
-.tidychat-nav-tip {
+/* 双类名 + !important：泡泡挂载在顶栏 header 内，部分样式主题（如 maid-atelier 换肤）会写
+   「header 内所有 nav/span/button/a/div」这类大范围 color:inherit 规则，优先级约 (0,3,2)，
+   单类名声明 (0,1,0) 必败，导致文字继承主题顶栏的浅色、落在浅色泡泡上不可读。
+   变量链保留：皮肤仍可通过 --tidychat-nav-tip-text / --tidychat-nav-tip-head 定制。 */
+.tidychat-nav-tip.tidychat-nav-tip {
   position: fixed;
   z-index: 41;
   pointer-events: none;
@@ -92,11 +96,11 @@ const CSS = `
   padding: 6px 10px;
   font-size: 12px;
   line-height: 1.5;
-  color: var(--tidychat-nav-tip-text, var(--dsw-alias-label-primary, #222));
+  color: var(--tidychat-nav-tip-text, var(--dsw-alias-label-primary, #222)) !important;
   overflow-wrap: anywhere; /* 摘要含长代码/长串时在框内折行，不撑破卡片 */
 }
 .tidychat-nav-tip-head {
-  color: var(--tidychat-nav-tip-head, var(--dsw-alias-label-secondary, #666));
+  color: var(--tidychat-nav-tip-head, var(--dsw-alias-label-secondary, #666)) !important;
   font-size: 11px;
   margin-bottom: 2px;
 }
@@ -1020,7 +1024,9 @@ export function apply(ctx: any): void {
   // 这样官方深色（半透明白玻璃）与样式主题保持 token 跟随，仅异常的不透明皮肤被纠正。
   const applyTipContrast = (): void => {
     const root = document.documentElement
-    const cs = getComputedStyle(document.documentElement)
+    // 主题 token 定义在 body 作用域（body / body[data-ds-dark-theme]），
+    // 从 html 读 computed 值永远是空串，会拿 '#222' 兜底值代替真实 token 测对比度。
+    const cs = getComputedStyle(document.body)
     const tipBg = parseRgba(cs.getPropertyValue('--dsw-alias-bg-layer-3').trim())
     const update = (key: string, token: string): void => {
       if (tipBg === null || tipBg[3] < 0.85) { root.style.removeProperty(key); return }


### PR DESCRIPTION
## 问题

安装样式主题（如 `@dsh-external/dsh-client-ui-skin-maid-atelier`）后，左缘定位条的悬停摘要泡泡（`.tidychat-nav-tip`）文字几乎不可读：实测计算样式为**浅色玻璃底 `rgba(224,231,246,0.88)` × 米白文字 `rgb(248,243,232)`**，对比度仅约 **1.1:1**（WCAG 正文要求 4.5:1）。

## 排查原委

在 DSH Web（带 maid-atelier 换肤）上用 DevTools 级联分析定位到完整证据链：

1. **背景为什么会变白**：插件写 `background: var(--dsw-alias-bg-layer-3, #fff)`，浅色模式下皮肤把该 token 定义为 `#e0e7f6e0`（浅蓝紫玻璃，88% 透明）。这一层是 token 的正常工作机制，不是 bug。

2. **文字为什么看不清（真正的 bug）**：泡泡由 React 挂载在顶栏 header 内部（`header[class*="header"]` 下的容器里）。皮肤里有这样一条「顶栏文字统一」规则：

   ```css
   body[data-dsh-maid-atelier]
     :is([data-pane="conversation"], [class*="centerCol"])
     header[class*="header"]
     :is(nav, span, button, a, div) { color: inherit; }
   ```

   泡泡恰好是 header 里的一个 `div`，全中。该规则优先级约 **(0,3,2)**，插件单类名声明 `.tidychat-nav-tip` 仅 **(0,1,0)**，必败。于是 `color: var(--tidychat-nav-tip-text, …)` 整条声明被 `color: inherit` 顶掉，文字继承顶栏的米白（皮肤为深蓝顶栏设计的浅色字），叠在浅色玻璃底上。

3. **为什么 v0.2.5 已有的 `applyTipContrast()` 自适应兜底没救回来**：
   - 它根本没机会生效——纠偏色写进 `--tidychat-nav-tip-text` 变量，但插件的 `color` 声明本身已被 `color: inherit` 覆盖，变量根本没被消费；
   - 且它从 `document.documentElement` 读 token，而主题 token 定义在 **body** 作用域（`body` / `body[data-ds-dark-theme]`），从 html 读 computed 值恒为空串，实际是用 `'#222'` 兜底值而非真实 token（`#172347`）测的对比度——测量对象就是错的。

## 修复

1. **级联层面**：`.tidychat-nav-tip` → `.tidychat-nav-tip.tidychat-nav-tip`（双类名）+ `color` 加 `!important`；`.tidychat-nav-tip-head` 同样处理（皮肤那条规则也会直接命中头部小字）。变量链原样保留，皮肤仍可通过 `--tidychat-nav-tip-text` / `--tidychat-nav-tip-head` 定制，自适应纠偏逻辑也照常工作。
2. **测量层面**：`applyTipContrast()` 改从 `document.body` 读 computed token，保证对比度测量基于真实主题值。

## 验证

在 DSH Web + maid-atelier 换肤（浅色模式）实测：

| 项目 | 修复前 | 修复后 |
|---|---|---|
| 泡泡文字 | `rgb(248,243,232)`（继承皮肤顶栏） | `rgb(23,35,71)` = token `#172347` |
| 对比度 | ≈ 1.1:1 | ≈ 12:1 |

深色模式行为不受影响（皮肤深色下 `bg-layer-3` 为 `#20315bf0`，走同一变量链）。
